### PR TITLE
fix(struct): replace i8s with bools

### DIFF
--- a/src/entities/plotsystem_city_projects.rs
+++ b/src/entities/plotsystem_city_projects.rs
@@ -11,7 +11,7 @@ pub struct Model {
     pub country_id: i32,
     pub name: String,
     pub description: String,
-    pub visible: i8,
+    pub visible: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src/entities/plotsystem_ftp_configurations.rs
+++ b/src/entities/plotsystem_ftp_configurations.rs
@@ -12,7 +12,7 @@ pub struct Model {
     pub address: String,
     pub port: i32,
     #[sea_orm(column_name = "isSFTP")]
-    pub is_sftp: i8,
+    pub is_sftp: bool,
     pub username: String,
     pub password: String,
 }

--- a/src/entities/plotsystem_plots.rs
+++ b/src/entities/plotsystem_plots.rs
@@ -20,7 +20,7 @@ pub struct Model {
     pub score: Option<i32>,
     pub last_activity: Option<DateTime>,
     pub create_date: DateTime,
-    pub pasted: i8,
+    pub pasted: bool,
     #[sea_orm(column_type = "Custom(\"LONGTEXT\".to_owned())", nullable)]
     pub outline: Option<String>,
 }

--- a/src/entities/plotsystem_plots.rs
+++ b/src/entities/plotsystem_plots.rs
@@ -20,7 +20,7 @@ pub struct Model {
     pub score: Option<i32>,
     pub last_activity: Option<DateTime>,
     pub create_date: DateTime,
-    pub pasted: bool,
+    pub pasted: i8,
     #[sea_orm(column_type = "Custom(\"LONGTEXT\".to_owned())", nullable)]
     pub outline: Option<String>,
 }

--- a/src/entities/plotsystem_reviews.rs
+++ b/src/entities/plotsystem_reviews.rs
@@ -12,7 +12,7 @@ pub struct Model {
     pub rating: String,
     pub feedback: String,
     pub review_date: DateTime,
-    pub sent: i8,
+    pub sent: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src/routes/post.rs
+++ b/src/routes/post.rs
@@ -49,7 +49,7 @@ pub async fn plot_add(
                 last_activity: NotSet,
                 create_date: NotSet,
                 create_player: Set(plot_json.create_player.to_owned()),
-                pasted: Set(0),
+                pasted: Set(false),
                 outline: Set(Some(plot_json.outline.to_owned())),
             };
 

--- a/src/routes/put.rs
+++ b/src/routes/put.rs
@@ -12,7 +12,7 @@ pub async fn set_pasted(
     _auth_preflag: AuthPreflag,
     _auth: AuthPutGuard,
     plot_id: i32,
-    pasted: i8,
+    pasted: bool,
 ) -> Status {
     let db = conn.into_inner();
 


### PR DESCRIPTION
Serde is capable of converting tinyints to boolean values, so the expression of tinyints from the DB to the API should be a boolean for semantics.

Resolves: #33